### PR TITLE
added bzr to while building the docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 ENV GOPATH /go
 ENV GOOS linux
 
-RUN apk add --update git bash
+RUN apk add --update git bash bzr
 
 ADD install-vips.sh install-vips.sh
 RUN ./install-vips.sh


### PR DESCRIPTION
Need bzr dependency for the lastet version of skipper.

Could you also please push the updated docker image to docker hub, if everything looks good?